### PR TITLE
move C file parsing __main__.py (#54)

### DIFF
--- a/pymwp/__main__.py
+++ b/pymwp/__main__.py
@@ -22,6 +22,8 @@ import argparse
 import sys
 import logging
 from typing import List, Optional
+from pycparser import parse_file, c_ast
+from subprocess import CalledProcessError
 
 from .analysis import Analysis
 from .version import __version__
@@ -39,11 +41,13 @@ def main():
 
     log_level = 0 if args.silent else 40
     log_filename = args.logfile
-    setup_logger(logging.FATAL - log_level, log_filename=log_filename)
+    logger = setup_logger(logging.FATAL - log_level, log_filename=log_filename)
     file_out = args.out or default_file_out(args.file)
+    use_cpp, cpp_path, cpp_args = not args.no_cpp, args.cpp, args.cpp_args
 
-    Analysis.run(args.file, file_out, args.no_save,
-                 not args.no_cpp, args.cpp, args.cpp_args)
+    logger.info(f'Starting analysis of {args.file}')
+    ast = parse_c_file(args.file, use_cpp, cpp_path, cpp_args, logger)
+    Analysis.run(ast, file_out, args.no_save)
 
 
 def _parse_args(
@@ -103,7 +107,7 @@ def _parse_args(
 
 def setup_logger(
         level: int = logging.ERROR,
-        log_filename: Optional[str] = None) -> None:
+        log_filename: Optional[str] = None) -> logging.Logger:
     """Create a configured instance of logger.
 
     Arguments:
@@ -126,6 +130,69 @@ def setup_logger(
         file_handler = logging.FileHandler(log_filename)
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
+    return logger
+
+
+def parse_c_file(
+        file: str, use_cpp: bool, cpp_path: str, cpp_args: str,
+        logger: logging.Logger
+) -> c_ast:
+    """Parse C file using pycparser.
+
+    Arguments:
+        file: path to C file
+        use_cpp: Set to True if you want to execute the C pre-processor
+            on the file prior to parsing it.
+        cpp_path: If use_cpp is True, this is the path to 'cpp' on your
+            system. If no path is provided, it attempts to just execute
+            'cpp', so it must be in your PATH.
+        cpp_args: If use_cpp is True, set this to the command line
+            arguments strings to cpp. Be careful with quotes - it's best
+            to pass a raw string (r'') here. If several arguments are
+            required, pass a list of strings.
+        logger: logger instance
+
+    Returns:
+        Generated AST
+    """
+    try:
+        ast = parse_file(file, use_cpp, cpp_path, cpp_args)
+        if use_cpp:
+            info = f'parsed with preprocessor: {cpp_path} {cpp_args}'
+        else:
+            info = 'parsed without preprocessor'
+        logger.debug(info)
+        validate_ast(ast, logger)
+        return ast
+    except CalledProcessError:
+        logger.error('Failed to parse C file. Terminating.')
+        sys.exit(1)
+
+
+def validate_ast(ast: c_ast, logger: logging.Logger) -> None:
+    """Check if successfully parsed AST can be analyzed.
+
+    Here we check that the C input file contains some source code
+    (has body) and that that body is not empty (has block_items).
+    These types of inputs do not cause the parser to error, so we
+    need to check these separately from parse error.
+
+    If the input is invalid terminate immediately.
+
+    Ref: [issue #4](https://github.com/seiller/pymwp/issues/4)
+
+    Arguments:
+        ast: AST object
+        logger: logger instance
+    """
+
+    invalid = ast is None or ast.ext is None or len(ast.ext) == 0
+    invalid = invalid or ast.ext[0].body is None or ast.ext[
+        0].body.block_items is None
+
+    if invalid:
+        logger.error('Input C file is invalid or empty.')
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/pymwp/analysis.py
+++ b/pymwp/analysis.py
@@ -1,8 +1,6 @@
-import sys
 import logging
-from subprocess import CalledProcessError
 from typing import List, Tuple
-from pycparser import parse_file, c_ast
+from pycparser import c_ast
 from pycparser.c_ast import Node, Assignment, If, While, For, Compound
 
 from .relation_list import RelationList, Relation
@@ -19,34 +17,20 @@ class Analysis:
 
     @staticmethod
     def run(
-            file_in: str, file_out: str = None, no_save: bool = False,
-            use_cpp: bool = True, cpp_path: str = None, cpp_args: str = None
+            ast: c_ast, file_out: str = None, no_save: bool = False
     ) -> Tuple[Relation, List[List[int]]]:
         """Run MWP analysis on specified input file.
 
         Arguments:
-            file_in: C source code file path
+            ast: parsed C source code AST
             file_out: where to store result
             no_save: Set true when analysis result should not be saved to file
-            use_cpp: Set to True if you want to execute the C pre-processor
-                on the file prior to parsing it.
-            cpp_path: If use_cpp is True, this is the path to 'cpp' on your
-                system. If no path is provided, it attempts to just execute
-                'cpp', so it must be in your PATH.
-            cpp_args: If use_cpp is True, set this to the command line
-                arguments strings to cpp. Be careful with quotes - it's best
-                to pass a raw string (r'') here. If several arguments are
-                required, pass a list of strings.
 
         Returns:
               Computed relation and list of non-infinity choices.
-
         """
 
         choices = [0, 1, 2]
-        logger.info(f'Starting analysis of {file_in}')
-        ast = Analysis.parse_c_file(file_in, use_cpp, cpp_path, cpp_args)
-        Analysis.validate_ast(ast)
 
         function_body = ast.ext[0].body
         index, relations, combinations = 0, RelationList(), []
@@ -500,61 +484,3 @@ class Analysis:
                  for val, scalar in enumerate(p2_scalars)]))
 
         return index + 1, vector
-
-    @staticmethod
-    def parse_c_file(
-            file: str, use_cpp: bool, cpp_path: str, cpp_args: str
-    ) -> c_ast:
-        """Parse C file using pycparser.
-
-        Arguments:
-            file: path to C file
-            use_cpp: Set to True if you want to execute the C pre-processor
-                on the file prior to parsing it.
-            cpp_path: If use_cpp is True, this is the path to 'cpp' on your
-                system. If no path is provided, it attempts to just execute
-                'cpp', so it must be in your PATH.
-            cpp_args: If use_cpp is True, set this to the command line
-                arguments strings to cpp. Be careful with quotes - it's best
-                to pass a raw string (r'') here. If several arguments are
-                required, pass a list of strings.
-
-        Returns:
-            Generated AST
-        """
-        try:
-            ast = parse_file(file, use_cpp, cpp_path, cpp_args)
-            if use_cpp:
-                info = f'parsed with preprocessor: {cpp_path} {cpp_args}'
-            else:
-                info = 'parsed without preprocessor'
-            logger.debug(info)
-            return ast
-        except CalledProcessError:
-            logger.error('Failed to parse C file. Terminating.')
-            sys.exit(1)
-
-    @staticmethod
-    def validate_ast(ast: c_ast) -> None:
-        """Check if successfully parsed AST can be analyzed.
-
-        Here we check that the C input file contains some source code
-        (has body) and that that body is not empty (has block_items).
-        These types of inputs do not cause the parser to error, so we
-        need to check these separately from parse error.
-
-        If the input is invalid terminate immediately.
-
-        Ref: [issue #4](https://github.com/seiller/pymwp/issues/4)
-
-        Arguments:
-            ast: AST object
-        """
-
-        invalid = ast is None or ast.ext is None or len(ast.ext) == 0
-        invalid = invalid or ast.ext[0].body is None or ast.ext[
-            0].body.block_items is None
-
-        if invalid:
-            logger.error('Input C file is invalid or empty.')
-            sys.exit(1)

--- a/tests/mocks/ast_mocks.py
+++ b/tests/mocks/ast_mocks.py
@@ -1,27 +1,13 @@
 """
-Sample ASTs for unit testing Analysis
+Preprocessed ASTs for unit testing analysis.py
 
-here we mock the outputs of pycparser.parse_file
+Here we mock the outputs of pycparser.parse_file
 
-These ASTs match the examples in c_files by name, or tests/mocks
+These ASTs match the examples in c_files by name, or C files in tests/mocks
 """
 
 from pycparser.c_ast import FileAST, FuncDef, Decl, FuncDecl, TypeDecl, \
     IdentifierType, Compound, Constant, While, BinaryOp, ID, Assignment, If
-
-EMPTY_MAIN = FileAST(ext=[FuncDef(decl=Decl(
-    name='main', quals=[], storage=[],
-    funcspec=[],
-    type=FuncDecl(
-        args=None,
-        type=TypeDecl(
-            declname='main',
-            quals=[],
-            type=IdentifierType(
-                names=['int']))),
-    init=None, bitsize=None),
-    param_decls=None,
-    body=Compound(block_items=None))])
 
 INFINITE_2C = FileAST(ext=[FuncDef(
     decl=Decl(name='main', quals=[],

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,39 +1,20 @@
-from pytest import raises
 from pymwp import Analysis, Polynomial
 from .mocks.ast_mocks import \
-    EMPTY_MAIN, INFINITE_2C, NOT_INFINITE_2C, IF_WO_BRACES, IF_WITH_BRACES, \
+    INFINITE_2C, NOT_INFINITE_2C, IF_WO_BRACES, IF_WITH_BRACES, \
     VARIABLE_IGNORED, EXTRA_BRACES
 
-PARSE_METHOD = 'pymwp.analysis.Analysis.parse_c_file'
 
-
-def test_analyze_empty_file(mocker):
-    """Empty C file raises non-zero system exit"""
-    mocker.patch(PARSE_METHOD, return_value=None)
-    with raises(SystemExit):
-        Analysis.run('empty input')
-
-
-def test_analyze_empty_main(mocker):
-    """Empty main method raises non-zero system exit"""
-    mocker.patch(PARSE_METHOD, return_value=EMPTY_MAIN)
-    with raises(SystemExit):
-        Analysis.run('empty main')
-
-
-def test_analyze_simple_infinite(mocker):
+def test_analyze_simple_infinite():
     """Check analysis result for infinite/infinite_2.c"""
-    mocker.patch(PARSE_METHOD, return_value=INFINITE_2C)
-    relation, combinations = Analysis.run("infinite 2", no_save=True)
+    relation, combinations = Analysis.run(INFINITE_2C, no_save=True)
 
     assert combinations == []  # no combinations since it is infinite
     assert relation.variables == []  # expected these variables
 
 
-def test_analyze_simple_non_infinite(mocker):
+def test_analyze_simple_non_infinite():
     """Check analysis result for not_infinite/notinfinite_2.c"""
-    mocker.patch(PARSE_METHOD, return_value=NOT_INFINITE_2C)
-    relation, combinations = Analysis.run("not infinite 2", no_save=True)
+    relation, combinations = Analysis.run(NOT_INFINITE_2C, no_save=True)
 
     # match expected choices and variables
     assert relation.variables == ['X0', 'X1']
@@ -45,10 +26,9 @@ def test_analyze_simple_non_infinite(mocker):
     assert str(relation.matrix[0][0].list[2]) == 'w.delta(2,0)'
 
 
-def test_analyze_if_with_braces(mocker):
+def test_analyze_if_with_braces():
     """If...else program using curly braces; result is 0-matrix."""
-    mocker.patch(PARSE_METHOD, return_value=IF_WITH_BRACES)
-    relation, combinations = Analysis.run("if_braces", no_save=True)
+    relation, combinations = Analysis.run(IF_WITH_BRACES, no_save=True)
 
     # match choices and variables
     assert relation.variables == ['x', 'x1', 'x2', 'x3', 'y']
@@ -64,11 +44,10 @@ def test_analyze_if_with_braces(mocker):
         raise
 
 
-def test_analyze_if_without_braces(mocker):
+def test_analyze_if_without_braces():
     """If...else program NOT using curly braces; result is 0-matrix, expect
     exact same output as previous test."""
-    mocker.patch(PARSE_METHOD, return_value=IF_WO_BRACES)
-    relation, combinations = Analysis.run("if_wo_braces", no_save=True)
+    relation, combinations = Analysis.run(IF_WO_BRACES, no_save=True)
 
     # match choices and variables
     assert relation.variables == ['x', 'x1', 'x2', 'x3', 'y']
@@ -84,11 +63,10 @@ def test_analyze_if_without_braces(mocker):
         raise
 
 
-def test_analyze_variable_ignore(mocker):
+def test_analyze_variable_ignore():
     """Analysis picks up variable on left of assignment,
     see issue #11: https://github.com/seiller/pymwp/issues/11 """
-    mocker.patch(PARSE_METHOD, return_value=VARIABLE_IGNORED)
-    relation, combinations = Analysis.run("variable_ignored", no_save=True)
+    relation, combinations = Analysis.run(VARIABLE_IGNORED, no_save=True)
 
     assert combinations == [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2],
                             [2, 0], [2, 1], [2, 2]]
@@ -114,11 +92,10 @@ def test_analyze_variable_ignore(mocker):
         raise
 
 
-def test_extra_braces_are_ignored(mocker):
+def test_extra_braces_are_ignored():
     """Analysis ignores superfluous braces in C program,
     see issue: #25: https://github.com/seiller/pymwp/issues/25"""
-    mocker.patch(PARSE_METHOD, return_value=EXTRA_BRACES)
-    relation, combinations = Analysis.run("extra_braces", no_save=True)
+    relation, combinations = Analysis.run(EXTRA_BRACES, no_save=True)
 
     assert set(relation.variables) == {'x', 'y'}
     assert relation.matrix[0][0] == Polynomial('m')


### PR DESCRIPTION
This change moves the C file parsing to occur before analysis.py and refactors unit tests accordingly.

Unit testing empty.c and empty_main.c in test_analysis.py is now not necessary because the file is checked to be not empty before analysis.py can be called. These two unit tests have been removed.