### PR TITLE
Add support for custom C headers

### DIFF
--- a/docs/analysis.md
+++ b/docs/analysis.md
@@ -4,6 +4,17 @@
 from pymwp import Analysis
 ```
 
+## Analyzing programs with custom headers
+
+Programs with custom header files require passing the path to header file location(s) as a command line argument.
+Use prefix `-I` followed by (relative or absolute) path to headers directory.
+For example, if header file is in directory `my_headers` then the required command line argument is:
+
+```text
+python -m pyalp my_program.c --cpp_args="-Imy_headers"
+```
+
+
 ::: pymwp.analysis
     selection:
       members:

--- a/docs/analysis.md
+++ b/docs/analysis.md
@@ -4,17 +4,6 @@
 from pymwp import Analysis
 ```
 
-## Analyzing programs with custom headers
-
-Programs with custom header files require passing the path to header file location(s) as a command line argument.
-Use prefix `-I` followed by (relative or absolute) path to headers directory.
-For example, if header file is in directory `my_headers` then the required command line argument is:
-
-```text
-python -m pyalp my_program.c --cpp_args="-Imy_headers"
-```
-
-
 ::: pymwp.analysis
     selection:
       members:

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,33 +17,33 @@ implemented and for which implementation is planned.
 - 🟧 &nbsp; **in progress** - implementation is in progress but not ready
 - ⬜ &nbsp; **planned** - implementation is in a planning stage
 
-Description | State | Example
---- | --- | ---
-**Basic data types** ||
- Integer types (incl. `signed`, `unsigned`) | ✅ | `char`, `short`, `int`, `long`, `long long`
- Floating point types  | ✅ | `float`, `double`, `long double` 
-**Declarations** ||
- Variable declarations |  ✅  | `int x;` 
- Constant declarations |  ✅  | `const int x;`
-**Unary operations** | 🟧 | `-x`, `--x`, `x++`, ... 
-**Binary operations** (+, *, -) | ✅ |  `x = y + z`
-**Ternary operations** | 🟧 |  `x = y + z * w`
-**Combined assignment operators** | 🟧 | `x += 1` |
-**Conditional statements** || 
- if statement | ✅ | `if(x > 0) { ... }`
- if-else statement | ✅ | `if(x > 0) { ... } else { ... }`
- nested conditional  | ✅ | `if(x > 0) {  if (y > 0) { ... } }` |
-**Repetition statements** || 
- while loop | ✅ | `while(x < 20) { ... }`
- for loop | 🟧 | `for (i = 0; i < 10; ++i) { ... }`
-**Functions** | 🟧 ||
-**Pointers** | 🟧 ||
-**Arrays** | 🟧 || 
- **Header Files Inclusion** | 🟧 || 
-**Comments** ||
- Single-line | ✅ | `// comment`
- Multi-line | ✅ | `/* comment */`
+| Description                                | State | Example                                     |
+|--------------------------------------------|-------|---------------------------------------------|
+| **Basic data types**                       |       |                                             |
+| Integer types (incl. `signed`, `unsigned`) | ✅     | `char`, `short`, `int`, `long`, `long long` |
+| Floating point types                       | ✅     | `float`, `double`, `long double`            |
+| **Declarations**                           |       |                                             |     
+| Variable declarations                      | ✅     | `int x;`                                    |
+| Constant declarations                      | ✅     | `const int x;`                              |
+| **Unary operations**                       | 🟧    | `-x`, `--x`, `x++`, ...                     |
+| **Binary operations** (+, *, -)            | ✅     | `x = y + z`                                 |
+| **Ternary operations**                     | 🟧    | `x = y + z * w`                             |
+| **Combined assignment operators**          | ⬜     | `x += 1`                                    |
+| **Conditional statements**                 |       |                                             |
+| if statement                               | ✅     | `if(x > 0) { ... }`                         |
+| if-else statement                          | ✅     | `if(x > 0) { ... } else { ... }`            |
+| nested conditional                         | ✅     | `if(x > 0) {  if (y > 0) { ... } }`         |
+| **Repetition statements**                  |       |                                             |
+| while loop                                 | ✅     | `while(x < 20) { ... }`                     |
+| for loop                                   | 🟧    | `for (i = 0; i < 10; ++i) { ... }`          |
+| **Functions**                              | 🟧    |                                             |     
+| **Pointers**                               | ⬜     |                                             |     
+| **Arrays**                                 | ⬜     |                                             |      
+| **Header Files Inclusion**                 | ✅     |                                             |      
+| **Comments**                               |       |                                             |
+| Single-line                                | ✅     | `// comment`                                |
+| Multi-line                                 | ✅     | `/* comment */`                             |
 
 ### Handling of unsupported operations
 
-Analysis will bypass any statement that is unsupported.
+Analysis will bypass any statement that is unsupported and raises a warning.

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,31 +18,34 @@ implemented and for which implementation is planned.
 - ⬜ &nbsp; **planned** - implementation is in a planning stage
 
 | Description                                | State | Example                                     |
-|--------------------------------------------|-------|---------------------------------------------|
+|--------------------------------------------|:-----:|---------------------------------------------|
 | **Basic data types**                       |       |                                             |
-| Integer types (incl. `signed`, `unsigned`) | ✅     | `char`, `short`, `int`, `long`, `long long` |
-| Floating point types                       | ✅     | `float`, `double`, `long double`            |
+| Integer types (incl. `signed`, `unsigned`) |   ✅   | `char`, `short`, `int`, `long`, `long long` |
+| Floating point types                       |   ✅   | `float`, `double`, `long double`            |
 | **Declarations**                           |       |                                             |     
-| Variable declarations                      | ✅     | `int x;`                                    |
-| Constant declarations                      | ✅     | `const int x;`                              |
-| **Unary operations**                       | 🟧    | `-x`, `--x`, `x++`, ...                     |
-| **Binary operations** (+, *, -)            | ✅     | `x = y + z`                                 |
-| **Ternary operations**                     | 🟧    | `x = y + z * w`                             |
-| **Combined assignment operators**          | ⬜     | `x += 1`                                    |
+| Variable declarations                      |   ✅   | `int x;`                                    |
+| Constant declarations                      |   ✅   | `const int x;`                              |
+| **Arithmetic operations**                  |       | 
+| Unary operations                           |  🟧   | `-x`, `--x`, `x++`, ...                     |
+| Binary operations ($+, \times, -$)         |   ✅   | `x = y + z`                                 |
+| $n$-ary operation                          |  🟧   | `x = y + z * w`                             |
+| Compound assignment operators              |   ⬜   | `x += 1`                                    |
 | **Conditional statements**                 |       |                                             |
-| if statement                               | ✅     | `if(x > 0) { ... }`                         |
-| if-else statement                          | ✅     | `if(x > 0) { ... } else { ... }`            |
-| nested conditional                         | ✅     | `if(x > 0) {  if (y > 0) { ... } }`         |
+| if statement                               |   ✅   | `if(x > 0) { ... }`                         |
+| if-else statement                          |   ✅   | `if(x > 0) { ... } else { ... }`            |
+| nested conditional                         |   ✅   | `if(x > 0) {  if (y > 0) { ... } }`         |
 | **Repetition statements**                  |       |                                             |
-| while loop                                 | ✅     | `while(x < 20) { ... }`                     |
-| for loop                                   | 🟧    | `for (i = 0; i < 10; ++i) { ... }`          |
-| **Functions**                              | 🟧    |                                             |     
-| **Pointers**                               | ⬜     |                                             |     
-| **Arrays**                                 | ⬜     |                                             |      
-| **Header Files Inclusion**                 | ✅     |                                             |      
+| while loop                                 |   ✅   | `while(x < 20) { ... }`                     |
+| for loop                                   |  🟧   | `for (i = 0; i < 10; ++i) { ... }`          |
+| **Functions**                              |  🟧   |                                             |     
+| **Pointers**                               |   ⬜   |                                             |     
+| **Arrays**                                 |   ⬜   |                                             |      
+| **Header Files Inclusion** \*              |   ✅   |                                             |      
 | **Comments**                               |       |                                             |
-| Single-line                                | ✅     | `// comment`                                |
-| Multi-line                                 | ✅     | `/* comment */`                             |
+| Single-line                                |   ✅   | `// comment`                                |
+| Multi-line                                 |   ✅   | `/* comment */`                             |
+
+\*) version > 0.1.6
 
 ### Handling of unsupported operations
 

--- a/docs/file_io.md
+++ b/docs/file_io.md
@@ -8,13 +8,6 @@ To generate file name for storing results
 from pymwp.file_io import default_file_out
 ```
 
-To parse a C file (for analysis):
-
-```python
-from pymwp.file_io import parse
-```
-
-
 To save or restore results as JSON:
 
 ```python

--- a/pymwp/__init__.py
+++ b/pymwp/__init__.py
@@ -9,8 +9,9 @@ __title__ = "pymwp"
 __author__ = "Clément Aubert, Thomas Rubiano, Neea Rusch, Thomas Seiller"
 __license__ = "CC BY-NC 4.0"
 
-from pymwp.delta_graphs import DeltaGraph
 from pymwp.version import __version__
+from pymwp.parser import Parser
+from pymwp.delta_graphs import DeltaGraph
 from pymwp.choice import Choices
 from pymwp.relation_list import RelationList
 from pymwp.relation import Relation

--- a/pymwp/__init__.py
+++ b/pymwp/__init__.py
@@ -8,8 +8,8 @@ pymwp: implementation of MWP analysis on C code in Python.
 __title__ = "pymwp"
 __author__ = "Clément Aubert, Thomas Rubiano, Neea Rusch, Thomas Seiller"
 __license__ = "CC BY-NC 4.0"
+__version__ = "0.1.6"
 
-from pymwp.version import __version__
 from pymwp.parser import Parser
 from pymwp.delta_graphs import DeltaGraph
 from pymwp.choice import Choices

--- a/pymwp/__main__.py
+++ b/pymwp/__main__.py
@@ -23,9 +23,8 @@ import logging
 import sys
 from typing import List, Optional
 
-from pymwp import Parser, Analysis
+from pymwp import Parser, Analysis, __version__
 from .file_io import default_file_out
-from .version import __version__
 
 
 def main():

--- a/pymwp/__main__.py
+++ b/pymwp/__main__.py
@@ -46,7 +46,8 @@ def main():
     if not args.no_cpp:
         parser_kwargs['cpp_path'] = args.cpp_path
         parser_kwargs['cpp_args'] = args.cpp_args
-    ast = Parser.parse(args.input_file, **(parser_kwargs or {}))
+    c_headers = args.headers.split(',') if args.headers else None
+    ast = Parser.parse(args.input_file, c_headers, **(parser_kwargs or {}))
 
     # run analysis
     Analysis.run(ast,
@@ -61,19 +62,19 @@ def __parse_args(
     """Setup available program arguments."""
     parser.add_argument(
         'input_file',
-        help="Path to C source code file you want to analyze",
+        help="C source code file you want to analyze",
         nargs="?"
     )
     parser.add_argument(
         '-o', '--out',
         action="store",
         dest="out",
-        help="output filename (with path) for storing analysis result",
+        help="file where to store analysis result",
     )
     parser.add_argument(
         "--logfile",
         action="store",
-        help="write analysis log messages to a file",
+        help="write analysis terminal messages to specified file",
     )
     parser.add_argument(
         '--cpp_path',
@@ -88,6 +89,11 @@ def __parse_args(
         help='arguments to pass to C pre-processor (default: -E)',
     )
     parser.add_argument(
+        "--headers",
+        action="store",
+        help="list of C header directory paths, separate by comma",
+    )
+    parser.add_argument(
         "--no_cpp",
         action='store_true',
         help="disable execution of C pre-processor on input file"
@@ -100,7 +106,7 @@ def __parse_args(
     parser.add_argument(
         "--no_save",
         action='store_true',
-        help="skip writing result to file"
+        help="do not write analysis result to a file"
     )
     parser.add_argument(
         '-s', "--silent",

--- a/pymwp/choice.py
+++ b/pymwp/choice.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 
 SEQ = Set[Tuple[Tuple[int, int], ...]]
 """Type hint to represent a sequence of deltas"""
+
 CHOICES = List[List[List[int]]]
 """Type hint for representing a list of choice vectors"""
 

--- a/pymwp/delta_graphs.py
+++ b/pymwp/delta_graphs.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 from typing import List, Optional, Tuple, Union
+
 from .monomial import Monomial
 
 
 class DeltaGraph:
     """
-    DeltaGraph is a dictionary representing a weighted graph
-    of tuple of deltas (also referenced here as monomial_list
-    aka: a monomial without its scalar).
+    DeltaGraph is a dictionary representing a weighted graph of tuple of
+    deltas (also referenced here as monomial_list aka: a monomial without
+    its scalar).
 
-    We use tuple here instead of list because we want them to be
-    hashable (as key in dictionary).
+    We use tuple here instead of list because we want them to be hashable (
+    as key in dictionary).
 
-    We will often refere to tuple of deltas as simple node.
-    But a node with lenght !
+    We will often refer to tuple of deltas as simple node. But a node with
+    length!
 
-    Nodes are "sorted" by this lenght in order to be compared by chunks of
+    Nodes are "sorted" by this length in order to be compared by chunks of
     same size.
 
     Weight of edge represents the index where the nodes differ.
@@ -70,13 +71,13 @@ class DeltaGraph:
         self.insert_tuple(tuple(m.deltas))
 
     def add_edge(self, node1, node2, label) -> None:
-        """Add an edge of label `label` btwn `node1` and `node2`
-        If one node does not exists, it's created
+        """Add an edge of label `label` between `node1` and `node2`
+        If one node does not exist, it's created
 
         Symmetry is also added in the graph
 
         Note:
-            node2 should always exists if add_edge is always called
+            node2 should always exist if add_edge is always called
             from insert_tuple
 
         Arguments:
@@ -190,10 +191,11 @@ class DeltaGraph:
             index: Optional[int] = None
     ) -> Tuple[bool, Union[int, Monomial]]:
         """Compares two nodes
-        Compares two lists of monomials (of the same lenth)
-        and returns (diff, i) where diff is True if and only if
-        both lists differ only on one element regarding to the same index
-        and i is the index of the corresponding delta.
+
+        Compares two lists of monomials (of the same length) and returns (
+        diff, i) where diff is True if and only if both lists differ only on
+        one element regarding the same index and i is the index of the
+        corresponding delta.
 
         Arguments:
             ml1: first monomial_list
@@ -264,7 +266,7 @@ class DeltaGraph:
 
         Arguments:
             n: size of nodes or "level"
-            mono: arround that node
+            mono: around that node
             index: index with to find clique
             max_choices: optional
 
@@ -336,7 +338,7 @@ class DeltaGraph:
         Returns:
             eliminates corresponding clique in the delta_graph
         """
-        # Start from longest monomial list to the shortest
+        # Start from the longest monomial list to the shortest
         for n in sorted(self.graph_dict, reverse=True):
             # For all monomial list of size n
             for lm in list(self.graph_dict[n]):

--- a/pymwp/file_io.py
+++ b/pymwp/file_io.py
@@ -1,15 +1,11 @@
-import os
-import sys
 import json
 import logging
-
+import os
 from typing import Tuple, Dict, Optional
-from pycparser import parse_file, c_ast
-from subprocess import CalledProcessError
 
 from .choice import Choices
-from .relation import Relation
 from .matrix import decode
+from .relation import Relation
 
 logger = logging.getLogger(__name__)
 RESULT_TYPE = Tuple[Optional[Relation], Optional[Choices], bool]
@@ -119,48 +115,3 @@ def load_relation(file_name: str) -> Dict[str, RESULT_TYPE]:
         result[function_name] = relation, combinations, infinity
 
     return result
-
-
-def parse(
-        file: str, use_cpp: bool = True, cpp_path: str = 'cpp',
-        cpp_args: str = '-E'
-) -> c_ast:
-    """Parse C file using pycparser.
-
-    Pycparser can parse files that cannot be analyzed in any meaningful way,
-    e.g. empty main, no main, etc. This method will also check that AST
-    has some meaningful content before returning the AST.
-
-    Arguments:
-        file: path to C file
-        use_cpp: (optional) Set to True if you want to execute the C
-            pre-processor on the file prior to parsing it; default: `True`
-        cpp_path: (optional) If use_cpp is True, this is the path to 'cpp' on
-            your system. If no path is provided, it attempts to just execute
-            'cpp', so it must be in your PATH, default: `cpp`
-        cpp_args: (optional) If use_cpp is True, set this to the command line
-            arguments strings to cpp. Be careful with quotes - it's best
-            to pass a raw string (r'') here. If several arguments are
-            required, pass a list of strings. default: `-E`
-
-    Raises:
-        System.exit: if file cannot be parsed or is invalid/un-analyzable.
-
-    Returns:
-        Generated AST
-    """
-    try:
-        ast = parse_file(file, use_cpp, cpp_path, cpp_args)
-
-        invalid = ast is None or ast.ext is None or \
-                  len(ast.ext) == 0 or \
-                  ast.ext[0].body is None or \
-                  ast.ext[0].body.block_items is None  # noqa: E127
-
-        if not invalid:
-            return ast
-
-        sys.exit('FATAL: Input C file is invalid or empty. Terminating.')
-
-    except CalledProcessError:
-        sys.exit('FATAL: Failed to parse C file. Terminating.')

--- a/pymwp/matrix.py
+++ b/pymwp/matrix.py
@@ -1,17 +1,16 @@
 # flake8: noqa: W605
 
 import logging
-
-from typing import Any, Optional, List
 from functools import reduce
+from typing import Any, Optional, List
 
 from .polynomial import Polynomial
 from .monomial import Monomial
 from .semiring import ZERO_MWP, UNIT_MWP
 
-ZERO = Polynomial([Monomial(ZERO_MWP)])
+ZERO = Polynomial(ZERO_MWP)
 
-UNIT = Polynomial([Monomial(UNIT_MWP)])
+UNIT = Polynomial(UNIT_MWP)
 
 logger = logging.getLogger(__name__)
 

--- a/pymwp/monomial.py
+++ b/pymwp/monomial.py
@@ -1,9 +1,9 @@
 # flake8: noqa: W605
 
 from __future__ import annotations
-from typing import Optional, List, Tuple
-from .constants import SetInclusion
+from typing import List, Optional, Tuple
 
+from .constants import SetInclusion
 from .semiring import ZERO_MWP, UNIT_MWP, prod_mwp, sum_mwp
 
 

--- a/pymwp/parser.py
+++ b/pymwp/parser.py
@@ -3,7 +3,7 @@ import tempfile
 from logging import getLogger
 
 # noinspection PyPackageRequirements,PyProtectedMember
-from typing import Any
+from typing import Any, List
 
 from pycparser import c_ast, parse_file
 from pycparser_fake_libc import directory as fake_libc_dir
@@ -116,7 +116,7 @@ class PyCParser(ParserInterface):
     """Implementation of the parser interface, using pycparser."""
 
     @staticmethod
-    def parse(file_name: str, **kwargs):
+    def parse(file_name: str, headers: List[str] = None, **kwargs):
 
         # build parser cpp arguments
         # always append -E and fake_libc args when C preprocessor
@@ -127,6 +127,9 @@ class PyCParser(ParserInterface):
             if '-E' not in args:
                 args.append(r'-E')
             args.append(r'-I' + fake_libc_dir)
+            if headers:
+                for h in headers:
+                    args.append(r'-I' + h)
             kwargs['cpp_args'] = args
         logger.debug(f'parser arguments: {kwargs}')
 

--- a/pymwp/parser.py
+++ b/pymwp/parser.py
@@ -1,0 +1,266 @@
+import os
+import tempfile
+from logging import getLogger
+
+# noinspection PyPackageRequirements,PyProtectedMember
+from typing import Any
+
+from pycparser import c_ast, parse_file
+from pycparser_fake_libc import directory as fake_libc_dir
+
+logger = getLogger(__name__)
+
+"""Interface the pycparser dependency.
+
+Make all explicit references to pycparser within this module.
+If some functionality is missing, extend this interface as necessary,
+then test the used functionality in tests/test_parser.py.
+Do not import pycparser directly elsewhere outside this module+test.
+
+The motivation for using this interface is to make it easier to
+test and replace this dependency with newer versions and ensuring it
+such upgrades do not break pymwp.
+"""
+
+
+# noinspection PyPep8Naming
+class ParserInterface:  # pragma: no cover
+    """Interface for C code parser."""
+
+    @staticmethod
+    def parse(full_file_name: str, **kwargs) -> dict:
+        """Extract text from the currently loaded file."""
+        pass
+
+    def is_func(self, node: Any) -> bool:
+        return False
+
+    @property
+    def AST(self):
+        return None
+
+    @property
+    def Assignment(self):
+        return None
+
+    @property
+    def BinaryOp(self):
+        return None
+
+    @property
+    def Break(self):
+        return None
+
+    @property
+    def Compound(self):
+        return None
+
+    @property
+    def Constant(self):
+        return None
+
+    @property
+    def Continue(self):
+        return None
+
+    @property
+    def Decl(self):
+        return None
+
+    @property
+    def DoWhile(self):
+        return None
+
+    @property
+    def For(self):
+        return None
+
+    @property
+    def FuncCall(self):
+        return None
+
+    @property
+    def FuncDef(self):
+        return None
+
+    @property
+    def ID(self):
+        return None
+
+    @property
+    def If(self):
+        return None
+
+    @property
+    def Node(self):
+        return None
+
+    @property
+    def NodeVisitor(self):
+        return None
+
+    @property
+    def ParamList(self):
+        return None
+
+    @property
+    def UnaryOp(self):
+        return None
+
+    @property
+    def While(self):
+        return None
+
+
+class PyCParser(ParserInterface):
+    """Implementation of the parser interface, using pycparser."""
+
+    @staticmethod
+    def parse(file_name: str, **kwargs):
+
+        # build parser cpp arguments
+        # always append -E and fake_libc args when C preprocessor
+        # is enabled
+        if kwargs.get('use_cpp', False):
+            args = kwargs.get('cpp_args', None)
+            args = args.split(' ') if args else []
+            if '-E' not in args:
+                args.append(r'-E')
+            args.append(r'-I' + fake_libc_dir)
+            kwargs['cpp_args'] = args
+        logger.debug(f'parser arguments: {kwargs}')
+
+        # if running windows there is no automated fix for you, boo hoo
+        # add headers manually
+
+        if os.name == 'nt':
+            warning = 'automatic pre-parser processing was not ' \
+                      'applied on Windows: manual fix may be needed'
+            logger.warning(warning)
+            # on Windows parse the original file as-is
+            return parse_file(file_name, **kwargs)
+
+        # read the original C program source
+        with open(file_name, "r+") as cfile:
+            c_prog = cfile.read()
+
+        # apply preprocessing steps
+        preprocessed = PyCParser.__add_attr_x(c_prog)
+        # convert to byte string
+        prog_bytes = str.encode(preprocessed)
+
+        # create temporary file copy where we apply custom preprocessing
+        fp = tempfile.NamedTemporaryFile(suffix=".c")
+        fp.write(prog_bytes)
+        fp.seek(0)
+        # pass the temporary file pointer to pycparser
+        ast = parse_file(fp.name, **kwargs)
+        fp.close()
+        return ast
+
+    def is_func(self, node: Any) -> bool:
+        return isinstance(node, self.FuncDef) and \
+               hasattr(node, 'body') and node.body.block_items
+
+    @staticmethod
+    def __add_attr_x(text: str) -> str:
+        """Conditionally add #define __attribute__(x) to C file
+        for pycparser.
+
+        See: <https://github.com/eliben/pycparser/wiki/FAQ#what-do-i-do
+        -about-__attribute__/>
+
+        Arguments:
+            text: C program file content as a string
+
+        Returns:
+            contents of C file, with attribute(x) included.
+        """
+        attr_x = '#define __attribute__(x)'
+        lines = text.split('\n')
+        not_found = not any([line.startswith(attr_x) for line in lines])
+        if not_found:
+            lines.insert(0, attr_x)
+            text = '\n'.join(lines)
+            logger.debug(f'inserted {attr_x}')
+        return text
+
+    @property
+    def AST(self):
+        return c_ast
+
+    @property
+    def Assignment(self):
+        return c_ast.Assignment
+
+    @property
+    def BinaryOp(self):
+        return c_ast.BinaryOp
+
+    @property
+    def Break(self):
+        return c_ast.Break
+
+    @property
+    def Compound(self):
+        return c_ast.Compound
+
+    @property
+    def Constant(self):
+        return c_ast.Constant
+
+    @property
+    def Continue(self):
+        return c_ast.Continue
+
+    @property
+    def Decl(self):
+        return c_ast.Decl
+
+    @property
+    def DoWhile(self):
+        return c_ast.DoWhile
+
+    @property
+    def For(self):
+        return c_ast.For
+
+    @property
+    def FuncCall(self):
+        return c_ast.FuncCall
+
+    @property
+    def FuncDef(self):
+        return c_ast.FuncDef
+
+    @property
+    def ID(self):
+        return c_ast.ID
+
+    @property
+    def If(self):
+        return c_ast.If
+
+    @property
+    def Node(self):
+        return c_ast.Node
+
+    @property
+    def NodeVisitor(self):
+        return c_ast.NodeVisitor
+
+    @property
+    def ParamList(self):
+        return c_ast.ParamList
+
+    @property
+    def UnaryOp(self):
+        return c_ast.UnaryOp
+
+    @property
+    def While(self):
+        return c_ast.While
+
+
+# Parser is an instance of the preferred parser implementation
+Parser = PyCParser()

--- a/pymwp/relation.py
+++ b/pymwp/relation.py
@@ -6,8 +6,8 @@ import logging
 from typing import Optional, Tuple, List
 
 from . import matrix as matrix_utils
-from .delta_graphs import DeltaGraph
 from .choice import Choices
+from .delta_graphs import DeltaGraph
 
 logger = logging.getLogger(__name__)
 

--- a/pymwp/relation_list.py
+++ b/pymwp/relation_list.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 from typing import List, Optional
 
-from .relation import Relation
 from .delta_graphs import DeltaGraph
+from .relation import Relation
 
 
 class RelationList:

--- a/pymwp/version.py
+++ b/pymwp/version.py
@@ -1,6 +1,0 @@
-# -*- coding: utf-8 -*-
-
-__version__ = "0.1.6"
-
-if __name__ == "__main__":
-    print(__version__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
-pycparser==2.21
+# do you want to add dependencies?
+# -> add package dependencies here and to setup.py
+# -> add development dependencies to requirements-dev.txt only
+pycparser
+pycparser-fake-libc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # do you want to add dependencies?
-# -> add package dependencies here and to setup.py
+# -> add package dependencies here (can have version) and to setup.py (w/o version)
 # -> add development dependencies to requirements-dev.txt only
-pycparser
+pycparser~=2.21
 pycparser-fake-libc

--- a/setup.py
+++ b/setup.py
@@ -3,49 +3,49 @@ import os
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-with open("README.md", "r", encoding="utf-8") as fh:
+with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()
 
-with open(os.path.join(here, "pymwp", "version.py")) as fh:
+with open(os.path.join(here, "pymwp", "__init__.py")) as fh:
     exec(fh.read())
 
+# noinspection PyUnresolvedReferences
 setuptools.setup(
-    name="pymwp",
+    name=__title__,
     version=__version__,
-    author="Clément Aubert, Thomas Rubiano, Neea Rusch, Thomas Seiller",
-    author_email="nrusch@augusta.edu",
-    packages=["pymwp"],
-    entry_points={
-        "console_scripts": ["pymwp = pymwp.__main__:main"],
-    },
-    description="Implementation of MWP analysis on C code in Python",
+    author=__author__,
+    author_email='nrusch@augusta.edu',
+    packages=['pymwp'],
+    entry_points={'console_scripts': ['pymwp = pymwp.__main__:main'], },
+    description=__desc__,
     long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/statycc/pymwp",
+    long_description_content_type='text/markdown',
+    url='https://github.com/statycc/pymwp',
     project_urls={
-        "Bug Tracker": "https://github.com/statycc/pymwp/issues",
-        "Documentation": "https://statycc.github.io/pymwp/",
+        'Bug Tracker': 'https://github.com/statycc/pymwp/issues',
+        'Documentation': 'https://statycc.github.io/pymwp/',
     },
     package_data={"": ["LICENSE"], },
     include_package_data=True,
     classifiers=[
-        "Natural Language :: English",
-        "Intended Audience :: Science/Research",
-        "Development Status :: 3 - Alpha",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Operating System :: OS Independent",
-        "Environment :: Console",
-        "Typing :: Typed",
-        "Topic :: Scientific/Engineering",
-        "Topic :: Software Development",
+        'Natural Language :: English',
+        'Intended Audience :: Science/Research',
+        'Development Status :: 3 - Alpha',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Operating System :: OS Independent',
+        'Environment :: Console',
+        'Typing :: Typed',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Software Development',
     ],
     python_requires=">=3.7",
     install_requires=[
-        'pycparser'
+        'pycparser',
+        'pycparser-fake-libc'
     ]
 )

--- a/tests/mocks/ast_mocks.py
+++ b/tests/mocks/ast_mocks.py
@@ -1,3 +1,5 @@
+# noinspection DuplicatedCode
+
 """
 Sample ASTs for unit testing Analysis
 
@@ -6,9 +8,10 @@ here we mock the outputs of pycparser.parse_file
 These ASTs match the examples in c_files by name, or tests/test_examples
 """
 
-from pycparser.c_ast import FileAST, FuncDef, Decl, FuncDecl, TypeDecl, \
-    IdentifierType, Compound, Constant, While, BinaryOp, ID, Assignment, If, \
-    ParamList, FuncCall, Return, ExprList
+from pycparser.c_ast import \
+    FileAST, FuncDef, Decl, FuncDecl, TypeDecl, IdentifierType, Compound, \
+    Constant, While, BinaryOp, ID, Assignment, If, ParamList, FuncCall, \
+    Return, ExprList
 
 # c_files/infinite/infinite_2.c
 INFINITE_2C = FileAST(ext=[FuncDef(
@@ -281,7 +284,7 @@ PARAMS = FileAST(ext=[FuncDef(
         block_items=[
             Assignment(op='=', lvalue=ID(name='x1'), rvalue=ID(name='x2'))]))])
 
-# c_files/implementation_paper/example5_a.c
+# c_files/implementation_paper/example15_a.c
 FUNCTION_CALL = FileAST(ext=[FuncDef(
     decl=Decl(name='f', quals=[], align=[], storage=[], funcspec=[],
               type=FuncDecl(args=ParamList(params=[
@@ -296,7 +299,7 @@ FUNCTION_CALL = FileAST(ext=[FuncDef(
                   type=TypeDecl(declname='f', quals=[], align=None,
                                 type=IdentifierType(names=['int']))),
               init=None, bitsize=None), param_decls=None, body=Compound(
-        block_items=[While(cond=ID(name='X1'), stmt=Compound(block_items=[
+        block_items=[While(cond=ID(name='b'), stmt=Compound(block_items=[
             Assignment(op='=', lvalue=ID(name='X2'),
                        rvalue=BinaryOp(op='+', left=ID(name='X1'),
                                        right=ID(name='X1')))])),
@@ -314,9 +317,12 @@ FUNCTION_CALL = FileAST(ext=[FuncDef(
                   type=TypeDecl(declname='foo', quals=[], align=None,
                                 type=IdentifierType(names=['int']))),
               init=None, bitsize=None), param_decls=None, body=Compound(
-        block_items=[Assignment(
-            op='=', lvalue=ID(name='X2'),
-            rvalue=BinaryOp(op='+', left=ID(name='X1'), right=ID(name='X1'))),
+        block_items=[
+            Assignment(op='=', lvalue=ID(name='X2'),
+                       rvalue=BinaryOp(op='+', left=ID(name='X1'),
+                                       right=ID(name='X1'))),
             Assignment(op='=', lvalue=ID(name='X1'),
-                       rvalue=FuncCall(name=ID(name='f'), args=ExprList(
-                           exprs=[ID(name='X2'), ID(name='X2')])))]))])
+                       rvalue=FuncCall(name=ID(name='f'),
+                                       args=ExprList(
+                                           exprs=[ID(name='X2'),
+                                                  ID(name='X2')])))]))])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,39 @@
+import pycparser
+
+"""
+Test imported external dependencies that are being used.
+
+The goal of these tests is to enable checking that dependency updates 
+do not break expected and existing behavior that is currently in use.
+
+To see what functionality is being used see parser interface in
+pymwp/parser.py
+"""
+
+
+def test_ast_node_types():
+    """Test for existence of different AST node types."""
+    assert hasattr(pycparser.c_ast, 'Assignment')
+    assert hasattr(pycparser.c_ast, 'BinaryOp')
+    assert hasattr(pycparser.c_ast, 'Break')
+    assert hasattr(pycparser.c_ast, 'Compound')
+    assert hasattr(pycparser.c_ast, 'Constant')
+    assert hasattr(pycparser.c_ast, 'Continue')
+    assert hasattr(pycparser.c_ast, 'Decl')
+    assert hasattr(pycparser.c_ast, 'DoWhile')
+    assert hasattr(pycparser.c_ast, 'For')
+    assert hasattr(pycparser.c_ast, 'FuncCall')
+    assert hasattr(pycparser.c_ast, 'FuncDef')
+    assert hasattr(pycparser.c_ast, 'ID')
+    assert hasattr(pycparser.c_ast, 'If')
+    assert hasattr(pycparser.c_ast, 'Node')
+    assert hasattr(pycparser.c_ast, 'NodeVisitor')
+    assert hasattr(pycparser.c_ast, 'ParamList')
+    assert hasattr(pycparser.c_ast, 'UnaryOp')
+    assert hasattr(pycparser.c_ast, 'While')
+
+
+def test_parse():
+    """Ensure parse function exists."""
+    assert hasattr(pycparser, 'parse_file')
+    assert callable(getattr(pycparser, 'parse_file'))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,8 @@
 import pycparser
 
+from pymwp import Parser
+from .mocks.ast_mocks import INFINITE_2C, INFINITE_8C, FUNCTION_CALL
+
 """
 Test imported external dependencies that are being used.
 
@@ -9,6 +12,13 @@ do not break expected and existing behavior that is currently in use.
 To see what functionality is being used see parser interface in
 pymwp/parser.py
 """
+
+PARSER_KWARGS = {'use_cpp': True, 'cpp_path': 'gcc', 'cpp_args': '-E'}
+
+
+def __compare__(a, b):
+    """ignores newlines"""
+    return a.replace('\n', '') == b.replace('\n', '')
 
 
 def test_ast_node_types():
@@ -37,3 +47,27 @@ def test_parse():
     """Ensure parse function exists."""
     assert hasattr(pycparser, 'parse_file')
     assert callable(getattr(pycparser, 'parse_file'))
+
+
+def test_ast_structure_infty2c():
+    """Parser should match mock result used for unit tests
+
+    If this (or subsequent similar tests) fails after parser version bump,
+    update the mock AST trees.
+    """
+    ast = Parser.parse('c_files/infinite/infinite_2.c', **PARSER_KWARGS)
+
+    assert str(ast) == str(INFINITE_2C)
+
+
+def test_ast_structure_infty8c():
+    ast = Parser.parse('c_files/infinite/infinite_8.c', **PARSER_KWARGS)
+
+    assert str(ast) == str(INFINITE_8C)
+
+
+def test_ast_structure_func_call():
+    ast = Parser.parse('c_files/implementation_paper/example15_a.c',
+                       **PARSER_KWARGS)
+
+    assert str(ast) == str(FUNCTION_CALL)


### PR DESCRIPTION
This enables user to specify C headers directories using `--headers` argument. Can include multiple paths by using comma separated list.

Also included: some code refactoring, interfacing the pycparser, updated docs.