### PR TITLE
Minimal choice fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Refer to **[statycc.github.io/pymwp](https://statycc.github.io/pymwp/)** for a d
 
 ## Installation
 
-Install latest release from PyPI
+Install the latest release from PyPI
 
 ```bash
 pip install pymwp

--- a/docs/choice.md
+++ b/docs/choice.md
@@ -6,7 +6,8 @@ from pymwp import Choices
 
 ## Determining valid choices
 
-This section gives a high-level description.
+Choice module calculates and generates a compact representation of analysis derivation result. 
+This section gives a high-level description of this process.
 
 | Input             | Data type   |                                                           |
 |-------------------|-------------|-----------------------------------------------------------|
@@ -24,7 +25,7 @@ This section gives a high-level description.
 
     Iteratively apply these simplifications until convergence.
 
-    !!! info "Simplification examples"
+    ??? example "Simplification example"
 
         (a) All possible choices at index 1 occur in the set: any choice at
         index 1 followed by sequence `(2,2)(1,4)` results in infinity.
@@ -67,7 +68,7 @@ This section gives a high-level description.
 
     Discard invalid and redundant vectors. Add remaining vectors to result.
 
-    !!! info "Choice vector example"
+    ??? example "Choice vector example"
 
         ```Python
         # remining after simplification
@@ -90,7 +91,7 @@ This section gives a high-level description.
     Choose one vector, then select one value at each vector index. 
     This yields a bounded result.
 
-    !!! info "Result example"
+    ???+ example "Result example"
 
         ```Python
         [  [[1], [1,2], [0,1,2]]  v  [[2], [0,1], [1,2]]  v ... ]
@@ -98,10 +99,9 @@ This section gives a high-level description.
         # => [1, 2, 2] is valid choice, so is [2,1,2] and [1,1,0] ... etc.
         ```
 
-
-        If all choices are valid, the result is a single vector
-          of length `i` and all choices exist at each vector index.
-        If non-$\infty$ derivation does not exist, the result is empty `[ ]`.
+    If all choices are valid, the result is a single vector
+    of length `i` and all choices exist at each vector index.
+    If non-$\infty$ derivation does not exist, the result is empty `[ ]`.
 
 
 ::: pymwp.choice

--- a/docs/choice.md
+++ b/docs/choice.md
@@ -4,5 +4,104 @@
 from pymwp import Choices
 ```
 
+## Determining valid choices
+
+This section gives a high-level description.
+
+| Input             | Data type   |                                                           |
+|-------------------|-------------|-----------------------------------------------------------|
+| `i`               | `int`       | (index) count of assignments in analyzed program function |
+| `choices`         | `List[int]` | possible inference choices at program point               |
+| `delta_sequences` | `Set[SEQ]`  | sequences of choices leading to $\\infty$ (from matrix)   |
+
+**Computation Steps**
+
+1. **Simplify**. Using $\delta$-sequences set, simplify it in two ways:
+
+    1. Replace combinations that can be represented by a single shorter
+      sequence.
+    2. Remove supersets.
+
+    Iteratively apply these simplifications until convergence.
+
+    !!! info "Simplification examples"
+
+        (a) All possible choices at index 1 occur in the set: any choice at
+        index 1 followed by sequence `(2,2)(1,4)` results in infinity.
+        Remove `a b c` and insert `[(2,2)(1,4)]` in their place.
+
+        ```Python
+        choices = [0,1,2]
+
+        # sequences before:
+          [(0,1)(2,2)(1,4)]     # a
+          [(1,1)(2,2)(1,4)]     # b
+          [(2,1)(2,2)(1,4)]     # c
+
+        # sequences after:
+          [(2,2)(1,4)]
+        ```
+
+        (b) Sequence `a` is subset of `b`. Since `b` cannot be selected
+        without selecting `a`, we can remove `b`.
+
+        ```Python
+        # sequences before:
+          [(0,0)]               # a
+          [(0,0)(0,1)(2,2)]     # b
+
+        # sequences after:
+          [(0,0)]
+        ```
+
+2. **Build the choice vectors.** Initially consider all choices as valid.
+   Then eliminate those that lead to infinity, for all possible
+   combinations.
+
+    Compute cross product of remaining $\delta$-sequences.
+    Iterate the product, for each:
+
+    - Create a vector whose length equals `i`.
+    - Each vector element is a set of `choices`.
+    - Eliminate choices that lead to infinity.
+
+    Discard invalid and redundant vectors. Add remaining vectors to result.
+
+    !!! info "Choice vector example"
+
+        ```Python
+        # remining after simplification
+        sequences = [[(0,0)], [(1,0)], [(2,1)(1,2)], [(2,0)(1,1)(1,2)]]
+   
+        # compute cross product of sequences, which gives e.g.
+        infty_path = [(0,0) (1,0) (2,1) (1,1)]
+
+        for each infinity path:
+
+            # initialize vector with all choices at each vector element
+            vector = [{0,1,2}, {0,1,2}, {0,1,2}]
+
+            # eliminate infinity path choices, to obtain:
+            vector = [{2}, {0}, {0,1,2}]  # add to result
+        ```
+
+3. **Result.** The result is a disjunction of choice vectors.
+
+    Choose one vector, then select one value at each vector index. 
+    This yields a bounded result.
+
+    !!! info "Result example"
+
+        ```Python
+        [  [[1], [1,2], [0,1,2]]  v  [[2], [0,1], [1,2]]  v ... ]
+
+        # => [1, 2, 2] is valid choice, so is [2,1,2] and [1,1,0] ... etc.
+        ```
+
+
+        If all choices are valid, the result is a single vector
+          of length `i` and all choices exist at each vector index.
+        If non-$\infty$ derivation does not exist, the result is empty `[ ]`.
+
 
 ::: pymwp.choice

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.snippets
   - pymdownx.magiclink
+  - pymdownx.details
   - admonition
 
 plugins:

--- a/pymwp/__main__.py
+++ b/pymwp/__main__.py
@@ -62,7 +62,7 @@ def __parse_args(
     """Setup available program arguments."""
     parser.add_argument(
         'input_file',
-        help="C source code file you want to analyze",
+        help="C source code file to analyze",
         nargs="?"
     )
     parser.add_argument(

--- a/pymwp/choice.py
+++ b/pymwp/choice.py
@@ -285,7 +285,7 @@ class Choices:
                             for n in set(idx_freq)])
 
             # This iteration will not produce a valid vector if all choices
-            # are eliminated at some index. If will also not produce the
+            # are eliminated at some index. It will also not produce the
             # optimal vector, if some delta is duplicated in the
             # infinities-set but not in this vector. Discard these choices
             # in both cases.

--- a/pymwp/choice.py
+++ b/pymwp/choice.py
@@ -230,11 +230,11 @@ class Choices:
 
             assume the paths leading to infinity are:
 
-            $\{ [(0,0)], [(1,0)], [(1,1)(0,3)] \}$
+            `[(0,0)], [(1,0)], [(1,1)(0,3)]`
 
             Then, the valid choices that do not lead to infinity are:
 
-            $[[ [2], [0,2], [0,1,2]]$  or  $[[2], [0,1,2], [1,2]]]$
+            `[[ [2], [0,2], [0,1,2]]`  or  `[[2], [0,1,2], [1,2]]]`
 
         Arguments:
             choices: list of valid choices for one index, e.g. [0,1,2]

--- a/pymwp/choice.py
+++ b/pymwp/choice.py
@@ -13,71 +13,8 @@ CHOICES = List[List[List[int]]]
 
 
 class Choices:
-    """Generates a compact representation of sequences of choices that do not
-    lead to infinity.
-
-    !!! Inputs
-        - list of valid choices at one index (e.g. $[0,1,2]$)
-        - index (int) - represents number of assignments in original program
-        - set of delta-sequences that lead to $\\infty$, obtained from matrix
-
-    Steps:
-
-    Using delta-sequences set, simplify the set in two ways:
-
-    1. replace combinations of delta sequences that can be represented by a
-       single, shorter sequence
-
-           ```Python
-           choices = [0,1,2]
-           a = [(0,1)(2,2)(1,4)]
-           b = [(1,1)(2,2)(1,4)]
-           c = [(2,1)(2,2)(1,4)]
-
-           # all possible choices are represented at index 1 therefore it
-           # does not matter which one is selected: if any choice at index 1
-           # is followed by sequence (2,2)(1,4) then the result is infinity.
-
-           # => remove a, b, c and insert [(2,2)(1,4)] in their place.
-           ```
-
-    2. remove all sequences that are contained by shorter sequences:
-
-       ```Python
-       a = [(0,0)]  b = [(0,0), (0,1), (2,2)]
-
-       # a is subset of b: b cannot be selected without selecting a
-       # thus b is redundant => remove b
-       ```
-
-    3. Repeat steps 1-2 until no more reduction can be applied.
-
-    4. Build the choice vectors: initialize all choices as valid, then
-       eliminate those that lead to infinity, for all possible combinations
-
-           ```Python
-           index = 3 # number of assignments in the program
-           choices = [0,1,2] # the possible choices at each assignment
-
-           # each element is a set of choices and len(vector) == index
-           vector = [{0,1,2}, {0,1,2}, {0,1,2}]
-
-           # delta choices that cause infinity
-           infinity_choices = { [(0,0)], [(1,0)], [(1,1)(0,3)] }
-
-           # eliminate infinity choice: [(0,0)]
-           vector = [{1,2}, {0,1,2}, {0,1,2}]
-
-           # eliminate infinity choice: [(1,0)]
-           vector = [{2}, {0,1,2}, {0,1,2}]
-
-           # infinity choice: [(1,1) (0,3)]
-           # considering all possible combinations yields 2 distinct vectors:
-           vectors = [[{2}, {0,1,2}, {1,2}], [{2}, {0,2}, {0,1,2}]]
-
-           # Read as: choose one of vectors (1st, 2nd) then at each index
-           # choose one of the remaining choices, to get a valid derivation.
-           ```
+    """Generates a compact representation of derivation rule choices that do
+       not lead to infinity. The result is empty if no such choice exists.
     """
 
     def __init__(self, vectors: CHOICES = None):

--- a/pymwp/choice.py
+++ b/pymwp/choice.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 
 SEQ = Tuple[Tuple[int, int], ...]
 """Type hint to represent a sequence of deltas."""
+
 CHOICES = List[List[List[int]]]
 """Type hint for representing a list of choice vectors."""
 
@@ -50,6 +51,7 @@ class Choices:
         sequences = Choices.simplify(choices, inf)
 
         # now only min unique paths that lead to infinity remain
+        # only sorted here for presentation purposes
         paths = [str(list(i)) for i in sorted(
             list(sequences), key=lambda x: (len(x), x))]
         logger.debug(f'infinity paths: {" # ".join(paths) or "None"}')
@@ -59,7 +61,7 @@ class Choices:
         return Choices(valid)
 
     def is_valid(self, *choices: int) -> bool:
-        """Check if some sequence of choices can be made without infinity.
+        """Checks if some sequence of choices can be made without infinity.
 
         Example:
 

--- a/pymwp/relation.py
+++ b/pymwp/relation.py
@@ -56,7 +56,7 @@ class Relation:
             variables: program variables
             matrix: relation matrix
         """
-        self.variables = (variables or [])[:]
+        self.variables = [v for v in (variables or []) if v]
         self.matrix = matrix or matrix_utils \
             .init_matrix(len(self.variables))
 

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -44,3 +44,18 @@ def test_is_valid_returns_correct_result():
     assert obj.is_valid(2, 1)
     assert obj.is_valid(0, 2)
     assert obj.is_valid(2, 2)
+
+
+def test_result_is_minimal():
+    # ref: https://github.com/statycc/pymwp/issues/80
+    index, choices = 3, [0, 1, 2]
+    infinite = {((0, 0),),
+                ((1, 0),),
+                ((2, 1), (1, 2)),
+                ((2, 0), (1, 1), (1, 2))}
+    result = Choices.generate(choices, index, infinite)
+
+    assert [[2], [0, 1, 2], [0, 2]] in result.valid
+    assert [[2], [0, 1], [0, 2]] not in result.valid
+    assert [[2], [0, 2], [0, 2]] not in result.valid
+    assert [[2], [0], [0, 1, 2]] in result.valid


### PR DESCRIPTION
- [x] improved docs around explaining the evaluation step (docs/choice.md)
- [x] fix for issue #80 and adds matching unit test:

https://github.com/statycc/pymwp/blob/327efe3e83f1cc0d4ff6f73f9d9f4aac8f80c85c/tests/test_choices.py#L49-L61

The example calls these "invalid" choices, but they are actually "valid but redundant" so we can remove them.