### PR TITLE
Compute mwp bound

### DIFF
--- a/docs/bound.md
+++ b/docs/bound.md
@@ -1,0 +1,7 @@
+# bound.py
+
+```python
+from pymwp import Bound
+```
+
+::: pymwp.bound 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
 - Demo: demo.md
 - Modules:
   - Analysis: analysis.md
+  - Bound: bound.md
   - Choice: choice.md
   - Delta Graph: delta_graphs.md
   - File I/O: file_io.md

--- a/pymwp/__init__.py
+++ b/pymwp/__init__.py
@@ -13,10 +13,10 @@ __version__ = "0.3.0"
 from pymwp.parser import Parser
 from pymwp.delta_graphs import DeltaGraph
 from pymwp.choice import Choices
+from pymwp.bound import Bound
 from pymwp.relation_list import RelationList
 from pymwp.relation import Relation
 from pymwp.polynomial import Polynomial
 from pymwp.monomial import Monomial
 from pymwp.result import Result
 from pymwp.analysis import Analysis
-

--- a/pymwp/bound.py
+++ b/pymwp/bound.py
@@ -1,0 +1,50 @@
+from typing import List
+
+
+class Bound:
+    """Represent MWP bound."""
+
+    def __init__(self):
+        self.m = []
+        self.w = []
+        self.p = []
+
+    def __str__(self):
+        m_str = ",".join(self.m)
+        w_str = ",".join(self.w)
+        p_str = ",".join(self.p)
+        return "(" + (';'.join([m_str, w_str, p_str])) + ")"
+
+    def append(self, scalar: str, var_name: str):
+        """append variable dependency in the right place by scalar."""
+        if scalar == 'm':
+            self.m.append(var_name)
+        if scalar == 'w':
+            self.w.append(var_name)
+        if scalar == 'p':
+            self.p.append(var_name)
+
+    @staticmethod
+    def calculate(variables: List[str], simple_mat: List[List[str]]):
+        """Calculates honest polynomials.
+
+        Arguments:
+            variables: variable names (list)
+            simple_mat: matrix of scalars
+
+        Returns:
+            mwp-bound dictionary.
+        """
+        result = {}
+        for col_id, name in enumerate(variables):
+            var_bound = Bound()
+            for row_id in range(len(simple_mat)):
+                var_bound.append(simple_mat[row_id][col_id], variables[row_id])
+            result[name] = var_bound
+        return result
+
+    @staticmethod
+    def show(bound_dict: dict):
+        """Helper to display the mwp bound nicely."""
+        b_str = [f'{k} ≤ {v}' for k, v in bound_dict.items()]
+        return ' ∧ '.join(b_str)

--- a/pymwp/choice.py
+++ b/pymwp/choice.py
@@ -36,7 +36,7 @@ class Choices:
     @property
     def infinite(self):
         return len(self.valid) == 0
-
+    
     @property
     def first_choice(self) -> Optional[tuple[int]]:
         """Gets the first valid derivation choice, if exists"""

--- a/pymwp/choice.py
+++ b/pymwp/choice.py
@@ -36,7 +36,7 @@ class Choices:
     @property
     def infinite(self):
         return len(self.valid) == 0
-    
+
     @property
     def first_choice(self) -> Optional[tuple[int]]:
         """Gets the first valid derivation choice, if exists"""

--- a/pymwp/choice.py
+++ b/pymwp/choice.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections import Counter
 from functools import reduce
-from typing import Tuple, List, Set, Union
+from typing import Tuple, List, Set, Union, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +36,13 @@ class Choices:
     @property
     def infinite(self):
         return len(self.valid) == 0
+
+    @property
+    def first_choice(self) -> Optional[tuple[int]]:
+        """Gets the first valid derivation choice, if exists"""
+        # take first vector, then first choice at each index
+        return tuple([choices[0] for choices in self.valid[0]]) \
+            if not self.infinite else None
 
     @staticmethod
     def generate(choices: List[int], index: int, inf: Set[SEQ]) -> Choices:

--- a/pymwp/monomial.py
+++ b/pymwp/monomial.py
@@ -167,6 +167,20 @@ class Monomial:
 
         return mono_product
 
+    def choice_scalar(self, *choices: int) -> Optional[str]:
+        """Determine if given sequence of choices matches monomial.
+
+        Arguments:
+            choices: tuple of choices
+
+        Returns:
+            Monomial's scalar if structure matches choices and None otherwise.
+        """
+        for (i, j) in self.deltas:
+            if not i == choices[j]:
+                return None
+        return self.scalar
+
     def copy(self) -> Monomial:
         """Make a deep copy of a monomial."""
         return Monomial(self.scalar, self.deltas[:])

--- a/pymwp/polynomial.py
+++ b/pymwp/polynomial.py
@@ -78,7 +78,7 @@ class Polynomial:
 
     def __str__(self):
         values = ''.join(['+' + str(m) for m in self.list]) or ('+' + ZERO_MWP)
-        return "  " + values
+        return " " + values
 
     def __eq__(self, other):
         return self.equal(other)
@@ -343,6 +343,20 @@ class Polynomial:
     def show(self) -> None:
         """Display polynomial."""
         print(str(self))
+
+    def choice_scalar(self, *choices: int) -> Optional[str]:
+        """For given sequence of choices, determine corresponding scalar.
+
+        Arguments:
+            choices: tuple of choices
+
+        Returns:
+            Scalar value matching choices or None.
+        """
+        for mono in self.list:
+            scalar = mono.choice_scalar(*choices)
+            if scalar:
+                return scalar
 
     @staticmethod
     def compare(delta_list1: list, delta_list2: list) -> Comparison:

--- a/pymwp/result.py
+++ b/pymwp/result.py
@@ -4,7 +4,7 @@ import logging
 import time
 from typing import Optional, Dict, Tuple
 
-from pymwp import Relation, Choices
+from pymwp import Relation, Choices, Bound
 from pymwp.choice import CHOICES
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,9 @@ class Result:
         self.relations[name] = (matrix, choices, infinite)
         if choices and not choices.infinite:
             simple = matrix.apply_choice(*choices.first_choice)
+            bound = Bound.calculate(simple.variables, simple.matrix)
             logger.info(f'MATRIX\n{simple}')
+            logger.info(f'BOUND: {Bound.show(bound)}')
         elif matrix:
             logger.info(f'\nMATRIX\n{matrix}')
         if infinite:

--- a/pymwp/result.py
+++ b/pymwp/result.py
@@ -44,7 +44,6 @@ class Result:
         if choices and not choices.infinite:
             simple = matrix.apply_choice(*choices.first_choice)
             bound = Bound.calculate(simple.variables, simple.matrix)
-            logger.info(f'MATRIX\n{simple}')
             logger.info(f'BOUND: {Bound.show(bound)}')
         elif matrix:
             logger.info(f'\nMATRIX\n{matrix}')

--- a/pymwp/result.py
+++ b/pymwp/result.py
@@ -41,10 +41,11 @@ class Result:
     ):
         """Appends function analysis outcome to result."""
         self.relations[name] = (matrix, choices, infinite)
-        if matrix:
+        if choices and not choices.infinite:
+            simple = matrix.apply_choice(*choices.first_choice)
+            logger.info(f'MATRIX\n{simple}')
+        elif matrix:
             logger.info(f'\nMATRIX\n{matrix}')
-        if choices and len(choices.valid) > 0:
-            logger.info(f'CHOICES: {choices.valid}')
         if infinite:
             logger.info(f'RESULT: {name} is infinite')
 

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -59,3 +59,15 @@ def test_result_is_minimal():
     assert [[2], [0, 1], [0, 2]] not in result.valid
     assert [[2], [0, 2], [0, 2]] not in result.valid
     assert [[2], [0], [0, 1, 2]] in result.valid
+
+
+def test_first_choice():
+    choices = [0, 1, 2]
+
+    # all choice except [0, 1, 0] -> first choice is (1, 0, 1)
+    infty1 = {((0, 0),), ((1, 1),), ((0, 2),)}
+    # only allow (2, 2)
+    infty2 = {((0, 0),), ((1, 0),), ((0, 1),), ((1, 1),)}
+
+    assert Choices.generate(choices, 3, infty1).first_choice == (1, 0, 1)
+    assert Choices.generate(choices, 2, infty2).first_choice == (2, 2)


### PR DESCRIPTION
This change introduces mwp bound calculation and changes the displayed output to show that bound. 

_This change impacts what is displayed in the terminal output ( mwp bound ✅  --  matrix 🚫 choices 🚫 )._

This is done by making the first valid choice, calculating the simple valued matrix, and from there converting that to a mwp-bound representation. This impacts only non-infinite programs for which a bound can be calculated.

The return type and behavior of the analysis remains the same. This is a "display change" and includes the necessary code changes to produce that display.

The bound class is a sketch and only added one unit test. This behavior should be tested/documented more rigorously later.