### PR TITLE
Fail details

### DIFF
--- a/pymwp/polynomial.py
+++ b/pymwp/polynomial.py
@@ -344,6 +344,14 @@ class Polynomial:
         """Display polynomial."""
         print(str(self))
 
+    @property
+    def some_infty(self) -> bool:
+        """True if some monomial yields an infinity choice."""
+        for mono in self.list:
+            if mono.scalar == 'i':
+                return True
+        return False
+
     def choice_scalar(self, *choices: int) -> Optional[str]:
         """For given sequence of choices, determine corresponding scalar.
 

--- a/pymwp/relation.py
+++ b/pymwp/relation.py
@@ -110,10 +110,11 @@ class Relation:
         return self.composition(other)
 
     @staticmethod
-    def relation_str(variables, matrix, sep=' '):
+    def relation_str(variables: List[str], matrix: List[List[any]]):
+        """Formatted string of variables and matrix."""
         right_pad = len(max(variables, key=len)) if variables else 0
         return '\n'.join(
-            [var.ljust(right_pad) + ' | ' + (sep.join(poly)).strip()
+            [var.ljust(right_pad) + ' | ' + (' '.join(poly)).strip()
              for var, poly in
              [(var, [str(matrix[i][j]) for j in range(len(matrix))])
               for i, var in enumerate(variables)]])
@@ -286,6 +287,22 @@ class Relation:
                     for j in range(self.matrix_size)]
                    for i in range(self.matrix_size)]
         return Relation(self.variables.copy(), matrix=new_mat)
+
+    def infty_vars(self):
+        """Generate a list of variables that for some choices, can raise
+        infinity result."""
+        possible_infty_pairs = []
+        for rid, row in enumerate(self.matrix):
+            source = self.variables[rid]
+            for cid, poly in enumerate(row):
+                if poly.some_infty:
+                    target = self.variables[cid]
+                    possible_infty_pairs.append((source, target), )
+        return possible_infty_pairs
+
+    def show_infty_pairs(self):
+        pairs = self.infty_vars()
+        return ' ; '.join([f'{s} ➔ {t}' for s, t in pairs])
 
     def to_dict(self) -> dict:
         """Get dictionary representation of a relation."""

--- a/pymwp/result.py
+++ b/pymwp/result.py
@@ -41,14 +41,17 @@ class Result:
     ):
         """Appends function analysis outcome to result."""
         self.relations[name] = (matrix, choices, infinite)
-        if choices and not choices.infinite:
-            simple = matrix.apply_choice(*choices.first_choice)
-            bound = Bound.calculate(simple.variables, simple.matrix)
-            logger.info(f'BOUND: {Bound.show(bound)}')
-        elif matrix:
-            logger.info(f'\nMATRIX\n{matrix}')
+        if not infinite:
+            if choices:
+                simple = matrix.apply_choice(*choices.first_choice)
+                bound = Bound.calculate(simple.variables, simple.matrix)
+                logger.info(f'BOUND: {Bound.show(bound)}')
+            else:
+                logger.info('Some bound exists')
         if infinite:
-            logger.info(f'RESULT: {name} is infinite')
+            logger.info(f'{name} is infinite')
+            if matrix:
+                logger.info(f'Problematic flows: {matrix.show_infty_pairs()}')
 
     def get_result(self):
         """Returns the analysis result.

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -231,3 +231,12 @@ def test_polynomial_init_shorthand_syntax():
     assert Polynomial('m') == Polynomial([Monomial('m')])
     assert Polynomial('w') == Polynomial([Monomial('w')])
     assert Polynomial('p') == Polynomial([Monomial('p')])
+
+
+def test_finds_infty_scalar():
+    p1 = Polynomial('m', 'w', 'p', 'p', 'm', 'i', 'p')
+    p2 = Polynomial(('m', (0, 0), (1, 1)), ('w', (1, 0), (0, 1)),
+                    ('p', (1, 0), (2, 1)), 'w')
+
+    assert p1.some_infty is True
+    assert p2.some_infty is False


### PR DESCRIPTION
This change will display in the output, the variable pairs for which some choice causes infinity. It is not specific but it is the first step in the direction of displaying meaningful output of where failure occurs. 

Right now it is a list. E.g., if variable pair  `x` (source) `y` (target) has $\infty$ coefficient in the matrix, it would display as `x ➔ y`; and the output is a list of such pairs. To get this output the `--fin` arg must be set to ensure run to completion.

Future enhancement would be to add more details to this output, like we had discussed previously. 