### PR TITLE
polynomial init

### DIFF
--- a/pymwp/matrix.py
+++ b/pymwp/matrix.py
@@ -116,7 +116,7 @@ def decode(matrix: List[List[List[dict]]]) -> List[List[Polynomial]]:
         Decoded matrix of polynomials.
     """
     return [[
-        Polynomial([Monomial(
+        Polynomial(*[Monomial(
             scalar=monomial["scalar"],
             deltas=monomial["deltas"])
             for monomial in polynomial])

--- a/pymwp/monomial.py
+++ b/pymwp/monomial.py
@@ -98,7 +98,7 @@ class Monomial:
             True otherwise
         """
         for b in m.deltas:
-            if not (b in self.deltas):
+            if b not in self.deltas:
                 return False
         return True
 

--- a/pymwp/polynomial.py
+++ b/pymwp/polynomial.py
@@ -36,7 +36,7 @@ class Polynomial:
 
     def __init__(
             self, *monomials:
-            Optional[Union[str, Monomial, List[Monomial], Tuple[str, DELTAS]]]
+            Optional[Union[str, Monomial, Tuple[str, DELTAS]]]
     ):
         """Create a polynomial.
 
@@ -67,13 +67,9 @@ class Polynomial:
         ```
 
         Arguments:
-            monomials: list of monomials
-            :rtype: object
+            monomials: arbitrary number of monomials
         """
-        m_list = [mono for list2d in [
-            [Monomial.format(v) for v in
-             (m if isinstance(m, List) else [m])] for
-            m in monomials] for mono in list2d]
+        m_list = [Monomial.format(v) for v in monomials]
         self.list = m_list if len(m_list) > 0 else [Monomial(ZERO_MWP)]
 
     def __str__(self):
@@ -98,12 +94,12 @@ class Polynomial:
     @staticmethod
     def inclusion(list_monom: list, mono: Monomial, i: int = 0) \
             -> Tuple[bool, int]:
-        """filter list_monom regarding to mono inclusion and return info
+        """filter list_monom regarding mono inclusion and return info.
 
-        remove all monomials of list_monom that are included in mono.
+        Remove all monomials of list_monom that are included in mono.
 
         return CONTAINS if one of monomials of list_monom contains mono
-        (regarding to Monomial.inclusion def).
+        (regarding Monomial.inclusion def).
 
         Arguments:
             list_monom: a list of monomials
@@ -127,7 +123,7 @@ class Polynomial:
                     i = i - 1  # shift left position
                 continue
             elif incl == SetInclusion.INCLUDED:
-                #  We don't want to add mono, inform with CONTAINS
+                # We don't want to add mono, inform with CONTAINS
                 return False, i
             j = j + 1
         # No inclusion
@@ -140,7 +136,7 @@ class Polynomial:
         - If one list is empty, the result will be the other list
         of polynomials.
 
-        Otherwise the operation will zip the two lists together
+        Otherwise, the operation will zip the two lists together
         and return a new polynomial of sorted monomials.
 
         Arguments:
@@ -204,7 +200,7 @@ class Polynomial:
                 j = j + 1
 
         sorted_monomials = Polynomial.sort_monomials(new_list)
-        return Polynomial(sorted_monomials).remove_zeros()
+        return Polynomial(*sorted_monomials).remove_zeros()
 
     def times(self, polynomial: Polynomial) -> Polynomial:
         """Multiply two polynomials.
@@ -303,7 +299,7 @@ class Polynomial:
                     index_list.append(smallest)
             # 7. repeat until done
 
-        return Polynomial(result).remove_zeros()
+        return Polynomial(*result).remove_zeros()
 
     def equal(self, polynomial: Polynomial) -> bool:
         """Determine if two polynomials are equal.
@@ -338,7 +334,7 @@ class Polynomial:
 
     def copy(self) -> Polynomial:
         """Make a deep copy of polynomial."""
-        return Polynomial([m.copy() for m in self.list])
+        return Polynomial(*[m.copy() for m in self.list])
 
     def show(self) -> None:
         """Display polynomial."""
@@ -545,4 +541,4 @@ class Polynomial:
 
         monomials = [Monomial(scalar, [(number, index)])
                      for number, scalar in enumerate(scalars)]
-        return Polynomial(monomials)
+        return Polynomial(*monomials)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -35,7 +35,7 @@ def test_resize_modifies_matrix_size():
     """Resizing matrix changes matrix size correctly, it preserves the
     polynomials from the input matrix, and when enlarging, the newly added
     positions are filled with identity matrix values."""
-    poly = Polynomial([Monomial('m')])
+    poly = Polynomial(Monomial('m'))
     before_resize = init_matrix(2, poly)
     after_resize = resize(before_resize, 5)
 
@@ -58,10 +58,10 @@ def test_resize_modifies_matrix_size():
 
 def test_matrix_sum():
     """Matrix sum should add two matrices element-wise."""
-    expected = Polynomial([Monomial('m', [(0, 0)]), Monomial('w', [(1, 1)])])
+    expected = Polynomial(Monomial('m', [(0, 0)]), Monomial('w', [(1, 1)]))
 
-    mat_a = init_matrix(2, Polynomial([Monomial('m', [(0, 0)])]))
-    mat_b = init_matrix(2, Polynomial([Monomial('w', [(1, 1)])]))
+    mat_a = init_matrix(2, Polynomial(Monomial('m', (0, 0))))
+    mat_b = init_matrix(2, Polynomial(Monomial('w', (1, 1))))
     result = matrix_sum(mat_a, mat_b)
 
     assert result[0][0] == expected
@@ -73,10 +73,10 @@ def test_matrix_sum():
 def test_matrix_prod():
     """Matrix product test -- here we check using an elaborate test case
     that the product is what it should be, at each position."""
-    p1 = Polynomial([Monomial('p', [(0, 1)]), Monomial('w', [(1, 1)])])
-    p2 = Polynomial([Monomial('m', [(0, 1)]), Monomial('w', [(1, 1)])])
-    p3 = Polynomial([Monomial('m', [(0, 2)]), Monomial('w', [(1, 2)])])
-    p4 = Polynomial([Monomial('p', [(0, 2)]), Monomial('w', [(1, 2)])])
+    p1 = Polynomial(Monomial('p', [(0, 1)]), Monomial('w', [(1, 1)]))
+    p2 = Polynomial(Monomial('m', [(0, 1)]), Monomial('w', [(1, 1)]))
+    p3 = Polynomial(Monomial('m', [(0, 2)]), Monomial('w', [(1, 2)]))
+    p4 = Polynomial(Monomial('p', [(0, 2)]), Monomial('w', [(1, 2)]))
 
     #          m p3 o
     #          o m  o
@@ -109,7 +109,7 @@ def test_matrix_prod():
 
 def test_encode():
     """Encoding converts matrix of polynomials to a list of dictionaries."""
-    p = Polynomial([Monomial('m', [(0, 1)])])
+    p = Polynomial(Monomial('m', [(0, 1)]))
     mat = init_matrix(2, p)
     encoded = encode(mat)
     expected = [
@@ -132,19 +132,19 @@ def test_decode():
     ]
 
     decoded = decode(sample)
-    expected = init_matrix(2, Polynomial([Monomial('m', [(0, 1)])]))
+    expected = init_matrix(2, Polynomial(Monomial('m', (0, 1))))
 
     assert decoded == expected
 
 
 def test_matrix_equals():
     """Two polynomial matrices are equal when their monomials match exactly."""
-    p1 = Polynomial([Monomial('m', [(0, 1), (1, 1)])])
-    p2 = Polynomial([Monomial('m', [(0, 1), (1, 1)])])
-    p3 = Polynomial([Monomial('m', [(0, 0)])])
-    p4 = Polynomial([Monomial('m', [(0, 0)])])
-    p5 = Polynomial([Monomial('m', [(1, 1), (2, 2)])])
-    p6 = Polynomial([Monomial('m', [(1, 1), (2, 2)])])
+    p1 = Polynomial(Monomial('m', [(0, 1), (1, 1)]))
+    p2 = Polynomial(Monomial('m', [(0, 1), (1, 1)]))
+    p3 = Polynomial(Monomial('m', [(0, 0)]))
+    p4 = Polynomial(Monomial('m', [(0, 0)]))
+    p5 = Polynomial(Monomial('m', [(1, 1), (2, 2)]))
+    p6 = Polynomial(Monomial('m', [(1, 1), (2, 2)]))
 
     m1 = [[o, p1, o], [p3, o, o], [o, o, p5]]
     m2 = [[o, p2, o], [p4, o, o], [o, o, p6]]
@@ -154,9 +154,8 @@ def test_matrix_equals():
 
 def test_matrix_not_equals():
     """Two matrices where monomials differ by deltas are not equal."""
-    p1 = Polynomial([Monomial('m', [(0, 1)])])
-    p2 = Polynomial([Monomial('m', [(1, 1)])])
-
+    p1 = Polynomial(Monomial('m', [(0, 1)]))
+    p2 = Polynomial(Monomial('m', [(1, 1)]))
     m1 = [[o, o, o], [o, o, o], [o, o, p1]]
     m2 = [[o, o, o], [o, o, o], [o, o, p2]]
 

--- a/tests/test_monomial.py
+++ b/tests/test_monomial.py
@@ -1,4 +1,3 @@
-from pytest import raises
 from pymwp import Monomial
 from pymwp.constants import SetInclusion
 

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -5,7 +5,7 @@ from pymwp import Polynomial, Monomial
 def test_polynomial_copy():
     """Copying a polynomial returns different reference but of identical
     content."""
-    p = Polynomial([Monomial('m', [(0, 0), (1, 1)])])
+    p = Polynomial(Monomial('m', [(0, 0), (1, 1)]))
     poly_copy = p.copy()
 
     assert poly_copy == p  # their data is identical
@@ -17,7 +17,7 @@ def test_poly_decl_equivalence():
     Both syntax define the same polynomial; the list
     brackets are superfluous.
     """
-    p1 = Polynomial([Monomial('m', [(0, 0), (1, 1)])])
+    p1 = Polynomial(Monomial('m', [(0, 0), (1, 1)]))
     p2 = Polynomial(Monomial('m', (0, 0), (1, 1)))
 
     assert len(p1.list) == len(p2.list) == 1
@@ -40,10 +40,9 @@ def test_poly_decl_shorthand():
 
 def test_poly_decl_equivalence_multi():
     """Both syntax define the same polynomial; many monomials."""
-    p1 = Polynomial([
+    p1 = Polynomial(
         Monomial('i', [(0, 0), (1, 1)]), Monomial('i'),
-        Monomial('w', [(1, 0), (2, 1), (0, 2)])
-    ])
+        Monomial('w', [(1, 0), (2, 1), (0, 2)]))
     p2 = Polynomial(Monomial('i', (0, 0), (1, 1)), Monomial('i'),
                     Monomial('w', (1, 0), (2, 1), (0, 2)))
 
@@ -56,7 +55,7 @@ def test_poly_decl_equivalence_multi():
 def test_polynomial_times_empty():
     """Multiplying two polynomials where one is 0-monomial, results in 0."""
     z = Polynomial(ZERO_MWP)
-    p = Polynomial([Monomial('m', [(0, 0), (1, 1)])])
+    p = Polynomial(Monomial('m', [(0, 0), (1, 1)]))
 
     assert (p * z) == Polynomial(ZERO_MWP)
 
@@ -82,11 +81,11 @@ def test_polynomial_add_by_non_empty():
     result."""
     mono1 = Monomial('m', [(2, 2)])
     mono2 = Monomial('m', [(0, 0), (1, 1)])
-    m = Polynomial([mono1])
-    p = Polynomial([mono2])
+    m = Polynomial(mono1)
+    p = Polynomial(mono2)
     c = p + m
     expected = Polynomial(
-        [Monomial('m', [(0, 0), (1, 1)]), Monomial('m', [(2, 2)])])
+        Monomial('m', [(0, 0), (1, 1)]), Monomial('m', [(2, 2)]))
 
     assert c == expected
 
@@ -96,12 +95,11 @@ def test_polynomial_add_simpl():
     mono1 = Monomial('m', [(0, 1), (0, 2), (0, 3)])
     mono2 = Monomial('w', [(0, 2), (0, 3), (0, 4)])
     mono3 = Monomial('p', [(0, 2), (0, 3), (0, 5)])
-    m = Polynomial(Polynomial.sort_monomials([mono1, mono2, mono3]))
-    print(m)
+    m = Polynomial(*Polynomial.sort_monomials([mono1, mono2, mono3]))
     mono0 = Monomial('w', [(0, 2), (0, 3)])
-    p = Polynomial([mono0])
+    p = Polynomial(mono0)
     c = p.add(m)
-    expected = Polynomial([mono0, mono3])
+    expected = Polynomial(mono0, mono3)
 
     assert c == expected
 
@@ -109,9 +107,9 @@ def test_polynomial_add_simpl():
 def test_polynomial_times_by_non_empty():
     """Multiplying two polynomials with monomials with deltas gives expected
      result."""
-    p1 = Polynomial([Monomial('m', [(2, 2)])])
-    p2 = Polynomial([Monomial('m', [(0, 0), (1, 1)])])
-    expected = Polynomial([Monomial('m', [(0, 0), (1, 1), (2, 2)])])
+    p1 = Polynomial(Monomial('m', [(2, 2)]))
+    p2 = Polynomial(Monomial('m', [(0, 0), (1, 1)]))
+    expected = Polynomial(Monomial('m', [(0, 0), (1, 1), (2, 2)]))
 
     assert (p1 * p2) == expected
 
@@ -121,22 +119,15 @@ def test_polynomial_times_by_non_empty2():
     mono12 = Monomial('m', [(1, 1)])
     mono2 = Monomial('m', [(0, 0)])
     mono22 = Monomial('m', [(3, 3)])
-    m = Polynomial([mono1, mono12])
-    p = Polynomial([mono2, mono22])
+    m = Polynomial(mono1, mono12)
+    p = Polynomial(mono2, mono22)
     c = p * m
-    expected = Polynomial([
+    expected = Polynomial(
         Monomial('m', [(0, 0), (1, 1)]),
         Monomial('m', [(0, 0), (2, 2)]),
         Monomial('m', [(1, 1), (3, 3)]),
-        Monomial('m', [(2, 2), (3, 3)])])
-    try:
-        assert c == expected
-    except AssertionError:
-        print("expected:")
-        print(expected)
-        print("prod:")
-        print(c)
-        raise
+        Monomial('m', [(2, 2), (3, 3)]))
+    assert c == expected
 
 
 def test_polynomial_equals_empty_are_equal():
@@ -148,15 +139,15 @@ def test_polynomial_equals_empty_are_equal():
 
 def test_polynomial_equals_same_returns_true():
     """equal returns true when two polynomials are the same."""
-    p1 = Polynomial([Monomial('m', [(0, 0), (1, 1), (2, 2)])])
-    p2 = Polynomial([Monomial('m', [(0, 0), (1, 1), (2, 2)])])
+    p1 = Polynomial(Monomial('m', [(0, 0), (1, 1), (2, 2)]))
+    p2 = Polynomial(Monomial('m', [(0, 0), (1, 1), (2, 2)]))
     assert p1.equal(p2) is True
 
 
 def test_polynomial_equals_different_returns_false():
     """equal returns false when two polynomials are different."""
-    p1 = Polynomial([Monomial('m', [(0, 0), (1, 1), (2, 2)])])
-    p2 = Polynomial([Monomial('m', [(1, 1), (3, 3)])])
+    p1 = Polynomial(Monomial('m', [(0, 0), (1, 1), (2, 2)]))
+    p2 = Polynomial(Monomial('m', [(1, 1), (3, 3)]))
 
     assert p1.equal(p2) is False
 
@@ -196,8 +187,8 @@ def test_polynomial_remove_zeros_with_deltas():
 
     see: https://github.com/statycc/pymwp/issues/16
     """
-    zero = Polynomial([Monomial('o')])
-    poly = Polynomial([Monomial('m', [(0, 0), (1, 1)])])
+    zero = Polynomial(Monomial('o'))
+    poly = Polynomial(Monomial('m', [(0, 0), (1, 1)]))
     after_add = zero + poly
 
     assert len(after_add.list) == 1
@@ -208,8 +199,8 @@ def test_polynomial_remove_zeros_no_deltas():
     """Adding two polynomials where one contains 0-monomial and another
     contains non-0 monomial without deltas, after addition, only the
     non-zero monomial remains in the result."""
-    zero = Polynomial([Monomial('o')])
-    poly = Polynomial([Monomial('w')])
+    zero = Polynomial(Monomial('o'))
+    poly = Polynomial(Monomial('w'))
     after_add = zero + poly
 
     assert len(after_add.list) == 1
@@ -219,7 +210,7 @@ def test_polynomial_remove_zeros_no_deltas():
 def test_polynomial_remove_zeros_empty():
     """For a polynomial that contains only 0-monomials, only one 0-monomial
     remains after removing zeros."""
-    poly = Polynomial([Monomial('o'), Monomial('o'), Monomial('o')])
+    poly = Polynomial(Monomial('o'), Monomial('o'), Monomial('o'))
     poly.remove_zeros()
 
     assert len(poly.list) == 1
@@ -228,9 +219,9 @@ def test_polynomial_remove_zeros_empty():
 
 def test_polynomial_init_shorthand_syntax():
     """Shorthand syntax gives equivalent polynomial as the longer syntax."""
-    assert Polynomial('m') == Polynomial([Monomial('m')])
-    assert Polynomial('w') == Polynomial([Monomial('w')])
-    assert Polynomial('p') == Polynomial([Monomial('p')])
+    assert Polynomial('m') == Polynomial(Monomial('m'))
+    assert Polynomial('w') == Polynomial(Monomial('w'))
+    assert Polynomial('p') == Polynomial(Monomial('p'))
 
 
 def test_finds_infty_scalar():


### PR DESCRIPTION
Performance tweak to simplify `Polynomial` initialization

Any of these is valid, as before:

-  [x] arbitrary monomials `Polynomial(mono1, mono2, mono3)`
-  [x] arbitary tuples of monomial form `Polynomial(('m',(0,0),(0,1)), ('w', (0,2)), 'p')`
-  [x] mix of any of the above: `Polynomial('m', mono3)`

But `List` type is no longer allowed:`Polynomial([mono1, mono2, mono3])` 😠 ⛔  

To initialize from a list, use the * operator before an iterable, or just remove the square brackets.